### PR TITLE
remove console.log when defining mousedown effect

### DIFF
--- a/src/extracted/useFocusedAndSelected.ts
+++ b/src/extracted/useFocusedAndSelected.ts
@@ -315,7 +315,6 @@ export function useFocusedAndSelected<Multiselectable extends boolean = false> (
             'mousedown',
             {
               createEffect: ({ index }) => event => {
-                console.log('mousedown')
                 event.preventDefault()
 
                 focus.exact(index)


### PR DESCRIPTION
While implementing the Listbox interface, I noticed the browser console kept outputting 'mousedown'.

https://github.com/baleada/vue-features/blob/fcdc8e0bbfbf2d526c382d468125fcfcc598c25e/src/extracted/useFocusedAndSelected.ts#L318